### PR TITLE
Add searching by github issue ID and request ID

### DIFF
--- a/tweb/src/main/frontend/src/js/vue/models/RequestList.ts
+++ b/tweb/src/main/frontend/src/js/vue/models/RequestList.ts
@@ -14,17 +14,20 @@ export default class RequestsList {
     }
 
     private _filter(requests: RequestDto[], filter: RequestListFilter) {
-        let isSearchAlwaysValid = (!filter.search || filter.search.length < 3);
+        let id = filter.idInSearch;
+        let isSearchAlwaysValid = !filter.search || (filter.search.length < 3 && !id);
         let isProjectAlwaysValid = !filter.project;
         let isTechAlwaysValid = !filter.tech || filter.tech.length == 0;
+        let regex = new RegExp(filter.search, 'i');
         return requests.filter((request: RequestDto) => {
-            let regex = new RegExp(filter.search, 'i');
             let valid;
             valid = filter.fase == 'all';
             valid = valid || (filter.fase == 'starred' && request.starred);
-            valid = valid || filter.fase == request.fase.toLowerCase();
+            valid = valid || (filter.fase == request.fase.toLowerCase());
             valid = valid && (isProjectAlwaysValid || filter.project.toLowerCase() == request.owner.toLowerCase());
-            valid = valid && (isSearchAlwaysValid || request.title.match(regex));
+            valid = valid && (isSearchAlwaysValid
+                             || (filter.search.length >= 3 && request.title.match(regex))
+                             || (id && (Number(id) == request.id || id == request.issueNumber)));
             valid = valid && (isTechAlwaysValid || filter.tech.every((f: string) => {
                 let regex = new RegExp(`^${f}$`, 'i');
                 return request.technologies.some((t: string) => regex.test(t));

--- a/tweb/src/main/frontend/src/js/vue/models/RequestListFilter.ts
+++ b/tweb/src/main/frontend/src/js/vue/models/RequestListFilter.ts
@@ -5,8 +5,14 @@ export default class RequestListFilter {
     fase: string;
 
     public get isFiltered() {
-        return (!!this.search && this.search.length >= 3)
+        return (!!this.search && (this.search.length >= 3 || this.idInSearch))
             || (!!this.tech && this.tech.length > 0)
             || (!!this.project && this.project.length > 0);
     }
+
+    public get idInSearch() {
+        let id = this.search && this.search.match(/^#?(\d+)$/);
+        return id && id[1];
+    }
 }
+


### PR DESCRIPTION
Closes #322.
Searching for either type of ID, with our without leading '#',
will find the relevant requests. The behavior of matching everything
when the search string is short is preserved (unless it looks like an ID search), 
and longer ID-like things in the title are still matched as well.

Not sure what the purpose of isFiltered in the filter and isEmpty in the Vue component are for,
seems like hasNoResults is enough. But I left the component alone.

btw, what does "fase" mean?