### PR TITLE
Add a whitespace-nowrap to the alert-body.

### DIFF
--- a/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
+++ b/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
@@ -92,6 +92,11 @@
     }
 }
 
+.alert-body {
+  white-space: nowrap;
+  padding-right: 2.5rem;
+}
+
 .alert-progress {
     position: absolute;
     left: -1px;


### PR DESCRIPTION
This fixes #377

We added a whitespace nowrap to ensue the body of the dialog
is never wrapped, regardless of the size of the body.
Because this might push the body of the alert over the close-X, we add a
padding to the right, to ensure the X and the body never overlap.