### PR TITLE
Feature 377 nowrap alert body

### DIFF
--- a/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
+++ b/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
@@ -93,7 +93,6 @@
 }
 
 .alert-body {
-  white-space: nowrap;
   padding-right: 2.5rem;
 }
 

--- a/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
+++ b/tweb/src/main/frontend/src/scss/fundrequest/_alert.scss
@@ -92,6 +92,11 @@
     }
 }
 
+.alert-body {
+  white-space: nowrap;
+  padding-right: 2.5rem;
+}
+
 .alert-progress {
     position: absolute;
     left: -1px;


### PR DESCRIPTION
This fixes #377

We added a whitespace nowrap to ensue the body of the dialog
is never wrapped, regardless of the size of the body.
Because this might push the body of the alert over the close-X, we add a
padding to the right, to ensure the X and the body never overlap.

This is a re-do of #427.
![schermafbeelding 2018-06-19 om 15 31 42](https://user-images.githubusercontent.com/77059/41600755-02aa53c0-73d7-11e8-9f0e-27e0d43426a2.png)
![schermafbeelding 2018-06-19 om 15 31 31](https://user-images.githubusercontent.com/77059/41600756-02c6431e-73d7-11e8-99bb-db4d1c43cf68.png)
![schermafbeelding 2018-06-19 om 15 30 54](https://user-images.githubusercontent.com/77059/41600757-02e3d5f0-73d7-11e8-901b-97ca7876d1d9.png)
![schermafbeelding 2018-06-19 om 15 30 35](https://user-images.githubusercontent.com/77059/41600758-0301cf92-73d7-11e8-8cfe-ff86e293a354.png)
![schermafbeelding 2018-06-19 om 15 30 20](https://user-images.githubusercontent.com/77059/41600759-03279100-73d7-11e8-8a12-739bdaf7c25f.png)




